### PR TITLE
Redirect taxi navigation to booking section

### DIFF
--- a/components/MobileMenu/index.js
+++ b/components/MobileMenu/index.js
@@ -33,7 +33,7 @@ const menus = [
   {
     id: 3,
     title: "Taxi",
-    link: "#taxi",
+    link: "/#taxi-booking",
   },
   {
     id: 4,
@@ -83,15 +83,26 @@ export default class MobileMenu extends Component {
     this.setState({ isMenuShow: false });
   };
 
+  handleTaxiLinkClick = (e, link) => {
+    e.preventDefault();
+
+    this.setState({ isMenuShow: false }, () => {
+      if (this.props.onTaxiNavigate) {
+        this.props.onTaxiNavigate();
+      } else if (typeof window !== "undefined") {
+        window.location.href = link;
+      }
+    });
+  };
+
   /**
    * Renders a list of menu items.
-   * If an item is "Taxi", it calls this.props.handleVisible().
+   * If an item is "Taxi", it scrolls/navigates to the booking section.
    * If an item has a submenu, it toggles Collapse.
    * If an item is "City Tours", it renders the dynamic city tours submenu.
    */
   renderMenu = (items) => {
     const { openIds } = this.state;
-    const { handleVisible } = this.props; // pull in the function passed from parent
 
     return (
       <ul>
@@ -128,14 +139,14 @@ export default class MobileMenu extends Component {
               </li>
             );
           }
-          // 3) The Taxi item: call the parent's handleVisible prop
+          // 3) The Taxi item: trigger smooth scroll/navigation
           else if (item.title === "Taxi") {
             return (
               <li key={item.id}>
                 <Link
                   style={{ backgroundColor: "orange" }}
                   href={item.link}
-                  onClick={handleVisible}
+                  onClick={(e) => this.handleTaxiLinkClick(e, item.link)}
                 >
                   {item.title}
                 </Link>

--- a/components/Navbar/index.js
+++ b/components/Navbar/index.js
@@ -1,19 +1,10 @@
 import React from "react";
 import Header from "../header";
-import { useDispatch, useSelector } from "react-redux";
-import { handleVisible } from "../../store/actions/action";
 
 export default function Navbar(props) {
-  const dispatch = useDispatch();
   const [scroll, setScroll] = React.useState(0);
 
   const handleScroll = () => setScroll(document.documentElement.scrollTop);
-
-  const visible = useSelector((state) => state.visibility.visible);
-
-  const toggleTaxiBooking = () => {
-    dispatch(handleVisible(visible));
-  };
 
   React.useEffect(() => {
     window.addEventListener("scroll", handleScroll);
@@ -24,7 +15,7 @@ export default function Navbar(props) {
 
   return (
     <div className={className}>
-      <Header handleVisible={toggleTaxiBooking} hClass={props.hClass} />
+      <Header hClass={props.hClass} />
     </div>
   );
 }

--- a/components/TaxiBookingPage/index.js
+++ b/components/TaxiBookingPage/index.js
@@ -47,9 +47,7 @@ const vehicleOptions = [
   },
 ];
 
-const TaxiBookingPage = (props) => {
-  const { handleVisible } = props || {};
-
+const TaxiBookingPage = () => {
   const [formData, setFormData] = useState({
     passengerName: "",
     email: "",
@@ -194,7 +192,7 @@ const TaxiBookingPage = (props) => {
       googleMapsApiKey={process.env.NEXT_PUBLIC_GOOGLE_API}
       libraries={["places"]}
     >
-      <div id="taxi-book__container" className="taxi-book__container">
+      <div id="taxi-booking" className="taxi-book__container">
         <form
           key={formKey}
           onSubmit={handleSubmit}

--- a/components/header/index.js
+++ b/components/header/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import Logo from "/public/images/logo-2.png";
 import Link from "next/link";
 import { connect } from "react-redux";
@@ -8,14 +8,29 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faWhatsapp } from "@fortawesome/free-brands-svg-icons";
 import Image from "next/image";
 import cities from "../../api/city"; // Import your cities array
+import { useRouter } from "next/router";
 
 const Header = (props) => {
-  const { handleVisible } = props;
-  const ClickHandler = (e) => {
-    window.scrollTo(10, 0);
+  const router = useRouter();
+
+  const ClickHandler = () => {
+    if (typeof window !== "undefined") {
+      window.scrollTo(10, 0);
+    }
   };
 
-  const { carts } = props;
+  const handleTaxiNavigation = React.useCallback(() => {
+    if (typeof window !== "undefined" && router.pathname === "/") {
+      const section = document.getElementById("taxi-booking");
+      if (section) {
+        section.scrollIntoView({ behavior: "smooth" });
+        window.history.replaceState(null, "", "/#taxi-booking");
+        return;
+      }
+    }
+
+    router.push("/#taxi-booking");
+  }, [router]);
 
   return (
     <div className="middle-header">
@@ -163,11 +178,12 @@ const Header = (props) => {
                     <li>
                       <Link
                         className="brush-highlight"
-                        onClick={() => {
-                          handleVisible();
+                        onClick={(e) => {
+                          e.preventDefault();
+                          handleTaxiNavigation();
                         }}
-                        href="#" // It's good practice to have a value for href
-                        title="Add Taxi Option"
+                        href="/#taxi-booking"
+                        title="Taxi Booking"
                       >
                         Taxi +
                       </Link>
@@ -257,7 +273,7 @@ const Header = (props) => {
                 </div>
               </div>
               <div className="col-md-2 col-sm-2 col-2">
-                <MobileMenu handleVisible={handleVisible} />
+                <MobileMenu onTaxiNavigate={handleTaxiNavigation} />
               </div>
             </div>
             <div className="clearfix"></div>


### PR DESCRIPTION
## Summary
- update the desktop and mobile navigation so the Taxi option scrolls to the booking form instead of toggling the modal
- expose the booking form container with a stable anchor id that the navigation targets
- simplify the navbar wrapper now that the visibility toggle is unused

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f72bdf22008326939843b10f531932